### PR TITLE
fix:The runtime matching rule is too weak

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -60,10 +60,10 @@ _.parseDevices = function(data) {
 
   var parseLine = function(line) {
 
-    if (!!~line.indexOf('--')) {
+    if (line.match(/--\s(.*)\s--/)) {
       var regExp = /--\s(.*)\s--/;
       var matches = regExp.exec(line);
-      runtime = matches[1];
+      runtime = matches[1] || '';
       return;
     }
 


### PR DESCRIPTION
### example:
```
== Devices ==
-- iOS 8.1 --
-- iOS 10.2 --
    iPhone 5 (27331666-3521-4F71-971D-BF5E21B7DF84) (Shutdown)
    iPhone 5s (4F96D0AF-63F9-4E1C-B2F8-9DC9874B4AA2) (Shutdown)
    hpmsim-iPhone-6 (1FF8B0C6-C945-429A-B278-B7FC70668A56) (Shutting Down)
    iPhone 6 (95CF8082-BBCA-4F1D-B5D7-0A14EB9F780F) (Shutdown)
    iPhone 6 Plus (549279BD-51AA-4AAA-ADBD-C4B66278E9D9) (Shutdown)
    iPhone 6s (13F9003C-ECCB-4685-8655-0A55DFAF5867) (Shutdown)
    iPhone 6s Plus (929AE01F-A41D-4D62-BC12-60AFFB486E60) (Shutdown)
    iPhone 7 (3B0DAB2E-8FD2-4BA0-8978-333228BA529A) (Shutdown)
    iPhone 7 Plus (59039FF2-4523-4E3D-80E3-BD272CDBCFD9) (Shutdown)
    iPhone SE (E9099E9A-D748-4E82-A4A0-F2D88497752E) (Shutdown)
-- tvOS 10.1 --
-- watchOS 3.1 --
    Apple Watch - 38mm (72D37C23-3023-437D-960A-B69CDCD14158) (Shutdown)
    Apple Watch - 42mm (6F551433-6566-4287-A288-2F4312882727) (Shutdown)
    Apple Watch Series 2 - 38mm (9485DBD6-641A-4CBC-B5B9-0BDEB61CC6A6) (Shutdown)
    Apple Watch Series 2 - 42mm (102CF7A5-E3DF-451C-B8D9-7E01EDAFD6D3) (Shutdown)
-- Unavailable: com.apple.CoreSimulator.SimRuntime.iOS-9-0 --
    iPhone 4s (630E9BEF-79B5-4046-AD49-39B116D464D0) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5 (BA19943A-63F1-4945-B15B-ADEA095EAAE8) (Shutdown) (unavailable, runtime profile not found)
    antmsim--iPhone-5s--9-0 (E86506E0-C215-4613-9B04-C820BC80BCEA) (Shutdown) (unavailable, runtime profile not found)
    iPhone 5s (C7182DC2-272A-4529-B0A3-25E9F93D700C) (Shutdown) (unavailable, runtime profile not found)
    antmsim--iPhone-6--9-0 (25BDD22B-AB4C-49AE-A730-C428804D0A23) (Creating) (unavailable, runtime profile not found)
    hpmsim-iPhone-6 (736EE06A-11E2-4B6E-9A1F-ED62E9C4B84B) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 (8C3C46A7-AFDD-4A08-A7C5-95820BADA6D4) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6 Plus (7A7FDCCE-AB2B-4649-8381-6F56DE1B0DFE) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6s (90AA6F68-D823-4D13-A655-E02E16B76908) (Shutdown) (unavailable, runtime profile not found)
    iPhone 6s Plus (4F43C4A5-9DFC-4FF7-A375-0D82F41BF1E5) (Shutdown) (unavailable, runtime profile not found)
    iPad 2 (370C666B-1D75-4DDF-A4A7-0975E29E1ED6) (Shutdown) (unavailable, runtime profile not found)
    iPad Retina (12D4FFDD-C4AD-4418-AE84-D414C84741DB) (Shutdown) (unavailable, runtime profile not found)
    iPad Air (01958323-DB46-4AE7-85B1-4D1EA633DC3A) (Shutdown) (unavailable, runtime profile not found)
    iPad Air 2 (0723BDD7-FEE9-4676-AB66-3BD8F5A2B1D8) (Shutdown) (unavailable, runtime profile not found)
-- Unavailable: com.apple.CoreSimulator.SimRuntime.watchOS-2-0 --
    Apple Watch - 38mm (6D62B145-CAEB-4861-9B6D-9A3B43E7081A) (Shutdown) (unavailable, runtime profile not found)
    Apple Watch - 42mm (7AD87728-06C3-4AB9-8EB4-9BD4A674A529) (Shutdown) (unavailable, runtime profile not found)
```
